### PR TITLE
Refactor polymorphism

### DIFF
--- a/src/puget/data.clj
+++ b/src/puget/data.clj
@@ -35,7 +35,7 @@
     (str \# tag \space (pr-str value))))
 
 
-(defn ->tagged-value
+(defn tagged-value
   "Creates a generic tagged value record to represent some EDN value. This is
   suitable for use as a default-data-reader function."
   [tag value]
@@ -67,7 +67,7 @@
        ExtendedNotation
        (->edn
          [this#]
-         (->tagged-value ~tag (value-fn# this#))))))
+         (tagged-value ~tag (value-fn# this#))))))
 
 
 (defmacro extend-tagged-str

--- a/src/puget/printer.clj
+++ b/src/puget/printer.clj
@@ -163,6 +163,9 @@
 ;; ## Canonize Multimethod
 
 (defn- canonize-dispatch
+  "Dispatches the method to use for value formatting. Values which use
+  extended notation are rendered as tagged values; others are dispatched on
+  their `type`."
   [value]
   (if (satisfies? data/ExtendedNotation value)
     ::tagged-value

--- a/src/puget/printer.clj
+++ b/src/puget/printer.clj
@@ -164,9 +164,9 @@
 
 (defn- canonize-dispatch
   [value]
-  (if (satisfies? data/TaggedValue value)
-    :tagged-value
-    (class value)))
+  (if (satisfies? data/ExtendedNotation value)
+    ::tagged-value
+    (type value)))
 
 
 (defmulti canonize
@@ -267,7 +267,7 @@
           [:span
            (canonize k)
            (cond
-             (satisfies? data/TaggedValue v) " "
+             (satisfies? data/ExtendedNotation v) " "
              (coll? v) (:map-coll-separator *options*)
              :else " ")
            (canonize v)])
@@ -358,10 +358,9 @@
 
 ;; ## Special Types
 
-(defmethod canonize :tagged-value
+(defmethod canonize ::tagged-value
   [tagged-value]
-  (let [tag   (data/edn-tag tagged-value)
-        value (data/edn-value tagged-value)]
+  (let [{:keys [tag value]} (data/->edn tagged-value)]
     [:span
      (color-doc :tag (str \# tag))
      (if (coll? value) :line " ")

--- a/test/puget/data_test.clj
+++ b/test/puget/data_test.clj
@@ -46,13 +46,13 @@
 
 
 (deftest generic-tagged-value
-  (let [data (data/->tagged-value 'foo :bar)
+  (let [data (data/tagged-value 'foo :bar)
         {:keys [tag value]} (data/->edn data)
         string (data/edn-str data)]
     (is (= 'foo tag))
     (is (= :bar value))
     (is (= "#foo :bar" (str data)))
-    (is (= data (edn/read-string {:default data/->tagged-value} string)))))
+    (is (= data (edn/read-string {:default data/tagged-value} string)))))
 
 
 (defrecord TestRecord [x y])

--- a/test/puget/printer_test.clj
+++ b/test/puget/printer_test.clj
@@ -125,9 +125,9 @@
 
 
 (deftest canonical-tagged-value
-  (let [tv (data/->tagged-value 'foo :bar/baz)]
+  (let [tv (data/tagged-value 'foo :bar/baz)]
     (is (= "#foo :bar/baz" (pprint-str tv))))
-  (let [tv (data/->tagged-value 'frobble/biznar [:foo :bar :baz])]
+  (let [tv (data/tagged-value 'frobble/biznar [:foo :bar :baz])]
     (is (= "#frobble/biznar\n[:foo :bar :baz]" (pprint-str tv)))))
 
 

--- a/test/puget/printer_test.clj
+++ b/test/puget/printer_test.clj
@@ -3,7 +3,7 @@
     [clojure.string :as str]
     [clojure.test :refer :all]
     (puget
-      [data :refer [TaggedValue]]
+      [data :as data]
       [printer :refer :all])))
 
 
@@ -92,9 +92,9 @@
       (should-fail-when-strict v)
       (is (= "#\"\\d+\"" (pprint-str v)))))
   (testing "vars"
-    (let [v #'TaggedValue]
+    (let [v #'*options*]
       (should-fail-when-strict v)
-      (is (= "#'puget.data/TaggedValue"
+      (is (= "#'puget.printer/*options*"
              (pprint-str v)))))
   (testing "atom"
     (let [v (atom :foo)]
@@ -125,13 +125,9 @@
 
 
 (deftest canonical-tagged-value
-  (let [tv (reify TaggedValue
-             (edn-tag [this] 'foo)
-             (edn-value [this] :bar/baz))]
+  (let [tv (data/->tagged-value 'foo :bar/baz)]
     (is (= "#foo :bar/baz" (pprint-str tv))))
-  (let [tv (reify TaggedValue
-             (edn-tag [this] 'frobble/biznar)
-             (edn-value [this] [:foo :bar :baz]))]
+  (let [tv (data/->tagged-value 'frobble/biznar [:foo :bar :baz])]
     (is (= "#frobble/biznar\n[:foo :bar :baz]" (pprint-str tv)))))
 
 


### PR DESCRIPTION
cc @gfredericks fixes #13 

This has a couple of changes around the polymorphism used in Puget:
- `TaggedValue` protocol renamed to `ExtendedNotation`.
- `GenericTaggedValue` record shortened to `TaggedValue`.
- `canonize` dispatches on `type` rather than `class` if the value does not use extended notation.

This last means you can provide arbitrary print rendering for types which don't use a tagged-value representation in EDN. I originally tried making the `->edn` conversion function a multimethod instead, but it didn't really work out cleanly.