### PR TITLE
Add a :print-fallback key to *options* to fall back on pr-str

### DIFF
--- a/src/puget/printer.clj
+++ b/src/puget/printer.clj
@@ -35,6 +35,10 @@
   The text placed between a map key and a collection value. The keyword :line
   will cause line breaks if the whole map does not fit on a single line.
 
+  `:print-fallback`
+  If true, falls back to to using pr-str rather than puget's default
+  unknown-document representation
+
   `:print-meta`
   If true, metadata will be printed before values. If nil, defaults to the
   value of *print-meta*.
@@ -55,6 +59,7 @@
    :strict false
    :map-delimiter ","
    :map-coll-separator " "
+   :print-fallback false
    :print-meta nil
    :print-color false
    :color-markup :ansi
@@ -121,7 +126,7 @@
 
 
 (defn- illegal-when-strict!
-  "Throws an exception if strict mode is enabled. The error indincates that the
+  "Throws an exception if strict mode is enabled. The error indicates that the
   given value has no EDN representation."
   [value]
   (when (:strict *options*)
@@ -202,14 +207,17 @@
    (unknown-document value (.getName (class value)) repr))
   ([value tag repr]
    (illegal-when-strict! value)
-   [:span
-    (color-doc :class-delimiter "#<")
-    (color-doc :class-name tag)
-    (color-doc :class-delimiter "@")
-    (system-id value)
-    " "
-    repr
-    (color-doc :class-delimiter ">")]))
+   (if (:print-fallback *options*)
+     [:span
+      (pr-str value)]
+     [:span
+      (color-doc :class-delimiter "#<")
+      (color-doc :class-name tag)
+      (color-doc :class-delimiter "@")
+      (system-id value)
+      " "
+      repr
+      (color-doc :class-delimiter ">")])))
 
 
 

--- a/src/puget/printer.clj
+++ b/src/puget/printer.clj
@@ -37,7 +37,7 @@
 
   `:print-fallback`
   Takes a keyword argument specifying the desired string representation of
-  uknown documents. The keyword :print will fall back to using `pr-str`
+  unknown documents. The keyword `:print` will fall back to using `pr-str`
   rather than puget's default unknown-document representation. 
 
   `:print-meta`

--- a/src/puget/printer.clj
+++ b/src/puget/printer.clj
@@ -36,8 +36,9 @@
   will cause line breaks if the whole map does not fit on a single line.
 
   `:print-fallback`
-  If true, falls back to to using pr-str rather than puget's default
-  unknown-document representation
+  Takes a keyword argument specifying the desired string representation of
+  uknown documents. The keyword :print will fall back to using `pr-str`
+  rather than puget's default unknown-document representation. 
 
   `:print-meta`
   If true, metadata will be printed before values. If nil, defaults to the
@@ -59,7 +60,7 @@
    :strict false
    :map-delimiter ","
    :map-coll-separator " "
-   :print-fallback false
+   :print-fallback nil
    :print-meta nil
    :print-color false
    :color-markup :ansi
@@ -207,9 +208,8 @@
    (unknown-document value (.getName (class value)) repr))
   ([value tag repr]
    (illegal-when-strict! value)
-   (if (:print-fallback *options*)
-     [:span
-      (pr-str value)]
+   (case (:print-fallback *options*)
+     :print [:span (pr-str value)]
      [:span
       (color-doc :class-delimiter "#<")
       (color-doc :class-name tag)


### PR DESCRIPTION
This commit adds a `:print-fallback` key (default false) to the
puget.printer/*options* map. Setting the value to true will cause Puget
to fall back on an object's `pr-str` value rather than printing its
class information.

I believe this should resolve https://github.com/venantius/ultra/issues/8 once the dependency graph for Whidbey has also been updated. 