### PR TITLE
Add :escape-types option

### DIFF
--- a/src/puget/printer.clj
+++ b/src/puget/printer.clj
@@ -15,51 +15,66 @@
 (def ^:dynamic *options*
   "Printer control options.
 
-  `:width`
+  #### General Rendering
+
+  `:width`<br/>
   Number of characters to try to wrap pretty-printed forms at.
 
-  `:sort-keys`
+  `:print-meta`<br/>
+  If true, metadata will be printed before values. If nil, defaults to the
+  value of `*print-meta*`.
+
+  `:sort-keys`<br/>
   Print maps and sets with ordered keys. Defaults to true, which will sort all
   collections. If a number, counted collections will be sorted up to the set
   size. Otherwise, collections are not sorted before printing.
 
-  `:strict`
-  If true, throw an exception if there is no canonical EDN representation for
-  a given value. This generally applies to any non-primitive value which does
-  not extend puget.data/TaggedValue and is not a built-in collection.
-
-  `:map-delimiter`
+  `:map-delimiter`<br/>
   The text placed between key-value pairs in a map.
 
-  `:map-coll-separator`
+  `:map-coll-separator`<br/>
   The text placed between a map key and a collection value. The keyword :line
   will cause line breaks if the whole map does not fit on a single line.
 
-  `:print-fallback`
-  Takes a keyword argument specifying the desired string representation of
-  unknown documents. The keyword `:print` will fall back to using `pr-str`
-  rather than puget's default unknown-document representation. 
 
-  `:print-meta`
-  If true, metadata will be printed before values. If nil, defaults to the
-  value of *print-meta*.
+  #### Type Handling
 
-  `:print-color`
+  `:print-fallback`<br/>
+  Keyword argument specifying how to format unknown values. The keyword
+  `:print` will fall back to using `pr-str` rather than the default
+  pretty-printed representation.
+
+  `:escape-types`<br/>
+  A set of symbols naming classes which should *not* be pretty-printed. Instead,
+  they will be rendered as unknown values. This can be useful for types which
+  define their own `print-method`, are extremely large nested structures, or
+  which Puget otherwise has trouble rendering.
+
+  `:strict`<br/>
+  If true, throw an exception if there is no canonical EDN representation for
+  a given value. This generally applies to any non-primitive value which does
+  not extend `ExtendedNotation` and is not a built-in collection.
+
+
+  #### Color Options
+
+  `:print-color`<br/>
   When true, ouptut colored text from print functions.
 
-  `:color-markup`
+  `:color-markup`<br/>
   :ansi for ANSI color text (the default),
   :html-inline for inline-styled html,
   :html-classes to use the names of the keys in the :color-scheme map
   as class names for spans so styling can be specified via CSS.
 
-  `:color-scheme`
+  `:color-scheme`<br/>
   Map of syntax element keywords to ANSI color codes."
   {:width 80
    :sort-keys true
    :strict false
    :map-delimiter ","
    :map-coll-separator " "
+   :escape-types nil
    :print-fallback nil
    :print-meta nil
    :print-color false
@@ -161,13 +176,20 @@
 ;; ## Formatting Multimethod
 
 (defn- formatter-dispatch
-  "Dispatches the method to use for value formatting. Values which use extended
+  "Dispatches the method to use for value formatting. Any types in the
+  `:escape-types` set use the default formatter; values which use extended
   notation are rendered as tagged literals; others are dispatched on their
   `type`."
   [value]
-  (if (satisfies? data/ExtendedNotation value)
-    ::tagged-literal
-    (type value)))
+  (let [class-sym (some-> value class .getName symbol)]
+    (cond
+      (contains? (:escape-types *options*) class-sym)
+        :default
+
+      (satisfies? data/ExtendedNotation value)
+        ::tagged-literal
+
+      :else (type value))))
 
 
 (defmulti format-doc

--- a/test/puget/printer_test.clj
+++ b/test/puget/printer_test.clj
@@ -132,7 +132,10 @@
   (testing "Unknown values"
     (let [usd (java.util.Currency/getInstance "USD")]
       (should-fail-when-strict usd)
-      (is (re-seq #"#<java.util.Currency@[0-9a-f]+ USD>" (pprint-str usd))))))
+      (is (re-seq #"#<java\.util\.Currency@[0-9a-f]+ USD>" (pprint-str usd)))
+      (with-options {:print-fallback :print
+                     :escape-types #{'puget.printer_test.TestRecord}}
+        (is (= "#<Currency USD>" (pprint-str usd)))))))
 
 
 (deftest metadata-printing

--- a/test/puget/printer_test.clj
+++ b/test/puget/printer_test.clj
@@ -128,14 +128,33 @@
     (is (= "#frobble/biznar\n[:foo :bar :baz]" (pprint-str tv)))))
 
 
+(deftype ComplexValue []
+  Object
+  (toString [_] "to-string"))
+
+(defmethod print-method ComplexValue
+  [this w]
+  (.write w "{{ complex value print }}"))
+
+(data/extend-tagged-str ComplexValue 'complex/val)
+
+
 (deftest default-formatting
   (testing "Unknown values"
     (let [usd (java.util.Currency/getInstance "USD")]
       (should-fail-when-strict usd)
       (is (re-seq #"#<java\.util\.Currency@[0-9a-f]+ USD>" (pprint-str usd)))
-      (with-options {:print-fallback :print
-                     :escape-types #{'puget.printer_test.TestRecord}}
-        (is (= "#<Currency USD>" (pprint-str usd)))))))
+      (with-options {:print-fallback :print}
+        (is (= "#<Currency USD>" (pprint-str usd))))))
+  (testing "Escaped types"
+    (let [cv (ComplexValue.)]
+      (with-options {:escape-types nil}
+        (is (= "#complex/val \"to-string\"" (pprint-str cv))))
+      (with-options {:escape-types #{'puget.printer_test.ComplexValue}}
+        (is (re-seq #"#<puget\.printer_test\.ComplexValue@[0-9a-f]+ to-string>" (pprint-str cv))))
+      (with-options {:escape-types #{'puget.printer_test.ComplexValue}
+                     :print-fallback :print}
+        (is (= "{{ complex value print }}" (pprint-str cv)))))))
 
 
 (deftest metadata-printing


### PR DESCRIPTION
@venantius 

Tracking PR for feedback. This adds an `:escape-types` option to Puget, which supplants the escape hatch you introduced in venantius/ultra@2fded317b8f150161a5855df61be81a520945c9e. I originally tried to add this feature to Whidbey, but then I realized that doesn't work well. The problem with doing this at the nrepl-middleware-level is that the escaping only happens on the _top level value_. Meaning, if a function returns a Datomic `DB` value, it will be escaped correctly. However, if it returns a simple data structure like a `[db]` then the database value is still rendered by Puget.

Addresses issues like those raised in venantius/ultra#17.