### PR TITLE
Move ISeq to `clojure-interface-handlers`

### DIFF
--- a/src/puget/printer.clj
+++ b/src/puget/printer.clj
@@ -276,17 +276,17 @@
      (let [doc (if (realized? value)
                  (format-doc printer @value)
                  (color/document printer :nil "pending"))]
-       (format-unknown printer value "Delay" doc)))
-
-   clojure.lang.ISeq
-   (fn iseq-handler
-     [printer value]
-     (fv/visit-seq printer value))})
+       (format-unknown printer value "Delay" doc)))})
 
 
 (def clojure-interface-handlers
   "Fallback print handlers for other Clojure interfaces."
-  {clojure.lang.IPending
+  {clojure.lang.ISeq
+   (fn iseq-handler
+     [printer value]
+     (fv/visit-seq printer value))
+
+   clojure.lang.IPending
    (fn pending-handler
      [printer value]
      (let [doc (if (realized? value)


### PR DESCRIPTION
ISeq is currently grouped in with concrete types rather than in the interface
section. This commit moves it to the clojure-interface-handlers map.