### PR TITLE
Bump fipp for JDK 11 support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
   :dependencies
   [[org.clojure/clojure "1.9.0"]
    [mvxcvi/arrangement "1.1.1"]
-   [fipp "0.6.12"]]
+   [fipp "0.6.13"]]
 
   :cljfmt
   {:remove-consecutive-blank-lines? false


### PR DESCRIPTION
* Current version of Fipp is incompatible with JDK 11. 
* This PR bumps Fipp to 0.6.13 which is compatible with JDK 11.

fipp issue : https://github.com/brandonbloom/fipp/issues/50
eftest issue : https://github.com/weavejester/eftest/issues/53

This is used as a dependency in eftest which in turn is used in boot for testing.