### PR TITLE
Add new "compact printer" which forgoes canonicalization for efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,19 @@ compact) fashion.
 ; IllegalArgumentException: No defined representation for class java.util.Currency: USD
 ```
 
+If you like the strictness of the canonical printer but don't need the
+guaranteed canonicalization, you can avoid unnecessary sorting by
+using the alternative `compact-printer`:
+
+```clojure
+=> (puget/render-out (puget/compact-printer) (set (range 10)))
+#{0 7 1 4 6 3 2 9 5 8}
+
+=> (puget/render-out (puget/compact-printer) usd)
+; IllegalArgumentException No defined representation for class java.util.Currency: USD
+```
+
+
 ## Type Extensions
 
 All of Clojure's primitive types are given their standard print representations.

--- a/src/puget/printer.clj
+++ b/src/puget/printer.clj
@@ -326,7 +326,7 @@
 ;; ## Canonical Printer Implementation
 
 (defrecord CanonicalPrinter
-  [print-handlers]
+  [print-handlers sort-keys]
 
   fv/IVisitor
 
@@ -376,14 +376,14 @@
   (visit-set
     [this value]
     (let [entries (map (partial format-doc this)
-                       (sort order/rank value))]
+                       (order-collection sort-keys value (partial sort order/rank)))]
       [:group "#{" [:align (interpose " " entries)] "}"]))
 
   (visit-map
     [this value]
     (let [entries (map #(vector :span (format-doc this (key %))
                                 " "   (format-doc this (val %)))
-                       (sort-by first order/rank value))]
+                       (order-collection sort-keys value (partial sort order/rank)))]
       [:group "{" [:align (interpose " " entries)] "}"]))
 
 
@@ -428,7 +428,19 @@
   ([]
    (canonical-printer nil))
   ([handlers]
-   (assoc (CanonicalPrinter. handlers)
+   (assoc (CanonicalPrinter. handlers true)
+          :width 0)))
+
+
+(defn compact-printer
+  "Constructs a new compact printer with the given handler dispatch. A
+  compact printer strictly serializes the data according to the
+  handler dispatch, but does not guarantee canonicalization (keys are
+  not sorted)."
+  ([]
+   (compact-printer nil))
+  ([handlers]
+   (assoc (CanonicalPrinter. handlers false)
           :width 0)))
 
 

--- a/test/puget/printer_test.clj
+++ b/test/puget/printer_test.clj
@@ -103,6 +103,24 @@
       (java.util.Currency/getInstance "USD"))))
 
 
+(deftest compact-collections
+  (let [printer (compact-printer)]
+    (are [v] (= v (read-string (render-str printer v)))
+      '(foo :bar)
+      #{:omega :alpha :beta}
+      {:foo 8, :bar 'baz})
+    (are [v text] (= text (render-str printer v))
+      [:a :b :c]            "[:a :b :c]"
+      (sorted-set :a :b :c) "#{:a :b :c}"
+      (sorted-set-by
+        (comp - compare)
+        :a :b :c)           "#{:c :b :a}"
+      (sorted-map 1 2, 3 4) "{1 2 3 4}"
+      (sorted-map-by
+        (comp - compare)
+        1 2, 3 4)           "{3 4 1 2}")))
+
+
 
 ;; ## Pretty Printing
 


### PR DESCRIPTION
When using puget to serialize API payloads, the canonical printer is helpful for its strictness in datatypes, but the guaranteed canonicalization isn't crucial, and sometimes it noticeably slows down the overall serialization. To make this use case more efficient, I'd like to add a `compact-printer`, that is like the `canonical-printer` except it forgoes the sorting behavior.