### PR TITLE
Upgrade fipp to 0.6.14

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,9 +14,7 @@
   :dependencies
   [[org.clojure/clojure "1.9.0"]
    [mvxcvi/arrangement "1.1.1"]
-   [fipp "0.6.13"]
-   ; Fixed boxed-math warnings until fipp upgrades:
-   [org.clojure/core.rrb-vector "0.0.13"]]
+   [fipp "0.6.14"]]
 
   :cljfmt
   {:remove-consecutive-blank-lines? false


### PR DESCRIPTION
Fipp 0.6.14 has upgraded the rrb-vector dependency.

https://github.com/brandonbloom/fipp/commit/2bef22d3f47139c1ee60e7ec367fa31de9429c22