### PR TITLE
Add support for :coll-limit

### DIFF
--- a/src/puget/printer.clj
+++ b/src/puget/printer.clj
@@ -488,6 +488,7 @@
   [coll coll-limit]
   (and coll-limit (pos? coll-limit) (< coll-limit (count coll))))
 
+
 (defn visit-coll
   "Helper function that supports the other visit functions.
   order? should be false for ordered collection types like vector where any

--- a/src/puget/printer.clj
+++ b/src/puget/printer.clj
@@ -482,34 +482,20 @@
 
 ;; ## Pretty Printer Implementation
 
-(defprotocol Delimiters
-  "A protocol for string representation of delimiters"
-  (left-delimiter [this] "The string representation of the left delimiter")
-  (right-delimiter [this] "The string representation of the right delimiter")
-  (delimiter [this] "The string representation of the full delimiter"))
+(defn delimiter [coll]
+  (cond 
+    (vector? coll) "[]"
+    (set? coll) "#{}"
+    (map? coll) "{}"
+    :else "()"))
 
+(defn left-delimiter [coll]
+  (let [del (delimiter coll)]
+    (subs del 0 (dec (count del)))))
 
-(extend-protocol Delimiters
-  clojure.lang.PersistentList
-  (left-delimiter [this] "(")
-  (right-delimiter [this] ")")
-  (delimiter [this] "()")
-
-  clojure.lang.PersistentVector
-  (left-delimiter [this] "[")
-  (right-delimiter [this] "]")
-  (delimiter [this] "[]")
-
-  clojure.lang.APersistentSet
-  (left-delimiter [this] "#{")
-  (right-delimiter [this] "}")
-  (delimiter [this] "#{}")
-
-  clojure.lang.APersistentMap
-  (left-delimiter [this] "{")
-  (right-delimiter [this] "}")
-  (delimiter [this] "{}"))
-
+(defn right-delimiter [coll]
+  (let [del (delimiter coll)]
+    (subs del (dec (count del)))))
 
 (defn trim-coll? 
   [coll coll-limit]

--- a/src/puget/printer.clj
+++ b/src/puget/printer.clj
@@ -526,7 +526,7 @@
                    (order-collection sort-keys values (partial sort order/rank))
                    values)
           elements
-          (cond-> (if (symbol? (first values))
+          (cond-> (if (and (list? coll) (symbol? (first values)))
                     (cons (color/document this :function-symbol (str (first values)))
                           (map (partial format-doc this) (rest values)))
                     (map (partial format-doc this) values))

--- a/src/puget/printer.clj
+++ b/src/puget/printer.clj
@@ -488,6 +488,7 @@
   (right-delimiter [this] "The string representation of the right delimiter")
   (delimiter [this] "The string representation of the full delimiter"))
 
+
 (extend-protocol Delimiters
   clojure.lang.PersistentList
   (left-delimiter [this] "(")
@@ -514,6 +515,7 @@
   [coll coll-limit]
   (and coll-limit (pos? coll-limit) (< coll-limit (count coll))))
 
+
 (defn visit-coll 
   [this coll coll-limit order? sort-keys]
   (if (seq coll)
@@ -534,6 +536,7 @@
        [:align (interpose :line elements)]
        (color/document this :delimiter (right-delimiter coll))])
     (color/document this :delimiter (delimiter coll))))
+
 
 (defrecord PrettyPrinter
   [width

--- a/src/puget/printer.clj
+++ b/src/puget/printer.clj
@@ -47,7 +47,8 @@
 
   If set to a positive number, then collections will only render at most the 
   first n elements. This can help prevent unintentional printing of large 
-  collections. Note: Lazy sequences and ranges are controlled by `:seq-limit`
+  collections. Note: `:seq-limit` has higher precendence than `:coll-limit`
+  if both are set.
 
   #### Color Options
 
@@ -587,10 +588,12 @@
     (if (seq value)
       (if (instance? clojure.lang.PersistentList value)
         (visit-coll this value coll-limit false sort-keys)
-        (let [[values trimmed?]
-              (if (and seq-limit (pos? seq-limit))
-                (let [head (take seq-limit value)]
-                  [head (<= seq-limit (count head))])
+        (let [pos-int (fn [x] (if (and (integer? x) (pos? x)) x))
+              limit (or (pos-int seq-limit) (pos-int coll-limit))
+              [values trimmed?]
+              (if limit
+                (let [head (take limit value)]
+                  [head (<= limit (count head))])
                 [(seq value) false])
               elements
               (cond-> (if (symbol? (first values))

--- a/src/puget/printer.clj
+++ b/src/puget/printer.clj
@@ -579,8 +579,9 @@
     (if (seq value)
       (if (instance? clojure.lang.PersistentList value)
         (visit-coll this value coll-limit false sort-keys)
-        (let [pos-int (fn [x] (if (and (integer? x) (pos? x)) x))
-              limit (or (pos-int seq-limit) (pos-int coll-limit))
+        (let [limit (cond
+                      (pos-int? seq-limit) seq-limit
+                      (pos-int? coll-limit) coll-limit)
               [values trimmed?]
               (if limit
                 (let [head (take limit value)]

--- a/src/puget/printer.clj
+++ b/src/puget/printer.clj
@@ -510,10 +510,12 @@
   (delimiter [this] "{}"))
 
 
-(defn trim-coll? [coll coll-limit]
+(defn trim-coll? 
+  [coll coll-limit]
   (and coll-limit (pos? coll-limit) (< coll-limit (count coll))))
 
-(defn visit-coll [this coll coll-limit order? sort-keys]
+(defn visit-coll 
+  [this coll coll-limit order? sort-keys]
   (if (seq coll)
     (let [[values trimmed?] (if (trim-coll? coll coll-limit) 
                               [(take coll-limit coll) true]
@@ -618,8 +620,7 @@
   (visit-map
     [this value]
     (if (seq value)
-      (let [
-            [values trimmed?]
+      (let [[values trimmed?]
             (if (trim-coll? value coll-limit)
               [(take coll-limit value) true]
               [(order-collection sort-keys value (partial sort order/rank)) false])

--- a/test/puget/printer_test.clj
+++ b/test/puget/printer_test.clj
@@ -256,7 +256,25 @@
   (testing "lazy seq limits"
     (with-options {:seq-limit 4}
       (is (= "(1 2 3)" (pprint-str (map inc [0 1 2]))))
-      (is (= "(0 1 2 3 ...)" (pprint-str (range 100)))))))
+      (is (= "(0 1 2 3 ...)" (pprint-str (range 100))))))
+  (testing "coll-limit on lists"
+    (with-options {:coll-limit 4}
+      (is (= "(0 1 2)" (pprint-str '(0 1 2))))
+      (is (= "(0 1 2 3 ...)" (pprint-str '(0 1 2 3 4 5))))))
+  (testing "coll-limit on vectors"
+    (with-options {:coll-limit 4}
+      (is (= "[0 1 2]" (pprint-str [0 1 2])))
+      (is (= "[5 4 3 2 ...]" (pprint-str [5 4 3 2 1])))))
+  (testing "coll-limit on sets"
+    (with-options {:coll-limit 4}
+      (is (= "#{1 2 3}" (pprint-str #{3 2 1})))
+      (is (= "#{1 4 3 2 ...}" (pprint-str #{5 4 3 2 1})))))
+  (testing "coll-limit on maps"
+    (with-options {:coll-limit 3}
+      (is (= "{:a 1, :b 2, :c 3}" (pprint-str {:a 1 :b 2 :c 3})))
+      (is (= "{:a 1, :b 2, :c 3}" (pprint-str {:c 3 :b 2 :a 1})))
+      (is (= "{:a 1, :b 2, :c 3, ...}" (pprint-str {:a 1 :b 2 :c 3 :d 4})))
+      (is (= "{:d 4, :c 3, :b 2, ...}" (pprint-str {:d 4 :c 3 :b 2 :a 1}))))))
 
 
 (deftest pretty-color-options

--- a/test/puget/printer_test.clj
+++ b/test/puget/printer_test.clj
@@ -141,7 +141,8 @@
     {:foo 8 :bar 'baz}     "{:bar baz, :foo 8}"     ; gets sorted
     #{}                    "#{}"
     #{:omega :alpha :beta} "#{:alpha :beta :omega}" ; also sorted
-    (lazy-seq [:x])        "(:x)"))
+    (lazy-seq [:x])        "(:x)"
+    (first {:a 1})         "[:a 1]"))
 
 
 (deftest pretty-java-types

--- a/test/puget/printer_test.clj
+++ b/test/puget/printer_test.clj
@@ -253,10 +253,18 @@
           "common ns should be qualified even with other ns keys")
       (is (= "{\"a/x\" 1, :a/y 2}" (pprint-str {"a/x" 1, :a/y 2}))
           "any non-ident keys should prevent namespacing")))
-  (testing "lazy seq limits"
-    (with-options {:seq-limit 4}
+  (testing "lazy - seq-limit only"
+    (with-options {:seq-limit 4 :coll-limit nil}
       (is (= "(1 2 3)" (pprint-str (map inc [0 1 2]))))
       (is (= "(0 1 2 3 ...)" (pprint-str (range 100))))))
+  (testing "lazy - coll-limit only"
+    (with-options {:seq-limit nil :coll-limit 4}
+      (is (= "(1 2 3)" (pprint-str (map inc [0 1 2]))))
+      (is (= "(0 1 2 3 ...)" (pprint-str (range 100))))))
+  (testing "lazy - seq-limit has higher precesence than coll-limit"
+    (with-options {:seq-limit 5 :coll-limit 4}
+      (is (= "(1 2 3)" (pprint-str (map inc [0 1 2]))))
+      (is (= "(0 1 2 3 4 ...)" (pprint-str (range 100))))))
   (testing "coll-limit on lists"
     (with-options {:coll-limit 4}
       (is (= "(0 1 2)" (pprint-str '(0 1 2))))
@@ -276,6 +284,7 @@
       (is (= "{:a 1, :b 2, :c 3, ...}" (pprint-str {:a 1 :b 2 :c 3 :d 4})))
       (is (= "{:d 4, :c 3, :b 2, ...}" (pprint-str {:d 4 :c 3 :b 2 :a 1}))))))
 
+(number? nil)
 
 (deftest pretty-color-options
   (let [value [nil 1.0 true "foo" :bar]

--- a/test/puget/printer_test.clj
+++ b/test/puget/printer_test.clj
@@ -284,7 +284,6 @@
       (is (= "{:a 1, :b 2, :c 3, ...}" (pprint-str {:a 1 :b 2 :c 3 :d 4})))
       (is (= "{:d 4, :c 3, :b 2, ...}" (pprint-str {:d 4 :c 3 :b 2 :a 1}))))))
 
-(number? nil)
 
 (deftest pretty-color-options
   (let [value [nil 1.0 true "foo" :bar]


### PR DESCRIPTION
This pull request adds support for :coll-limit, as described and discussed in issue 50. :coll-limit keeps backwards compatibility with :seq-limit in the way that :seq-limit has higher precedence than :coll-limit when both are set.

https://github.com/greglook/puget/issues/50