### PR TITLE
Upgrade to fipp 0.6.24 to resolve java.sql.Timestamp issue.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,4 +13,4 @@
   :dependencies
   [[org.clojure/clojure "1.10.1"]
    [mvxcvi/arrangement "1.2.0"]
-   [fipp "0.6.23"]])
+   [fipp "0.6.24"]])


### PR DESCRIPTION
I get an exception running `lein-cprint` (which depends on `puget`) on Java >= 9 due to an issue with `fipp` with regards to `java.sql.Timestamp`. A `java.sql.Timestamp` [issue](https://github.com/brandonbloom/fipp/pull/78) was recently resolved in `fipp` and explicitly using the latest version of `fipp` in my leiningen plugin dependencies resolves my issue. As such, this PR upgrades `fipp` to 0.6.24 so that I can in turn upgrade `puget` in `lein-cprint` and resolve the issue.