### PR TITLE
Add support for Clojure 1.7 / 1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-...
+### Fixed
+
+- Add support for Clojure 1.7 and 1.8
 
 
 ## [1.3.2] - 2021-12-11

--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,6 @@
   [[lein-cloverage "1.2.2"]]
 
   :dependencies
-  [[org.clojure/clojure "1.11.0"]
-   [mvxcvi/arrangement "2.0.0"]
-   [fipp "0.6.25"]])
+  [[org.clojure/clojure "1.11.1"]
+   [mvxcvi/arrangement "2.1.0"]
+   [fipp "0.6.26"]])

--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,6 @@
   [[lein-cloverage "1.2.2"]]
 
   :dependencies
-  [[org.clojure/clojure "1.10.3"]
+  [[org.clojure/clojure "1.11.0"]
    [mvxcvi/arrangement "2.0.0"]
-   [fipp "0.6.24"]])
+   [fipp "0.6.25"]])

--- a/src/puget/printer.clj
+++ b/src/puget/printer.clj
@@ -91,6 +91,7 @@
     unknown value and is expected to return a formatting document representing
     it.
   "
+  (:refer-clojure :exclude [pos-int?])
   (:require
     [arrangement.core :as order]
     [clojure.string :as str]
@@ -169,6 +170,17 @@
 
 
 ;; ## Formatting Methods
+
+(defn- pos-int?
+  [x]
+  (if-let [core-pos-int? (resolve 'clojure.core/pos-int?)]
+    (core-pos-int? x)
+    (and (or (instance? Long x)
+             (instance? Integer x)
+             (instance? Short x)
+             (instance? Byte x))
+         (pos? x))))
+
 
 (defn- trim-coll?
   "Returns true if a collection should be trimmed according to the

--- a/src/puget/printer.clj
+++ b/src/puget/printer.clj
@@ -91,7 +91,6 @@
     unknown value and is expected to return a formatting document representing
     it.
   "
-  (:refer-clojure :exclude [pos-int?])
   (:require
     [arrangement.core :as order]
     [clojure.string :as str]
@@ -171,22 +170,16 @@
 
 ;; ## Formatting Methods
 
-(defn- pos-int?
+(defn- positive-integer?
   [x]
-  (if-let [core-pos-int? (resolve 'clojure.core/pos-int?)]
-    (core-pos-int? x)
-    (and (or (instance? Long x)
-             (instance? Integer x)
-             (instance? Short x)
-             (instance? Byte x))
-         (pos? x))))
+  (and (integer? x) (pos? x)))
 
 
 (defn- trim-coll?
   "Returns true if a collection should be trimmed according to the
   `:coll-limit` config."
   [coll coll-limit]
-  (and (pos-int? coll-limit) (< coll-limit (count coll))))
+  (and (positive-integer? coll-limit) (< coll-limit (count coll))))
 
 
 (defn- order-collection
@@ -575,7 +568,7 @@
       (let [limit (or seq-limit coll-limit)
 
             [elements trimmed?]
-            (if (pos-int? limit)
+            (if (positive-integer? limit)
               (let [head (take (inc limit) value)]
                 [(take limit head) (< limit (count head))])
               [value false])


### PR DESCRIPTION
Hi there, I maintain a test framework that uses Puget (thanks for the great lib!), and I was trying to bump to a new version of Puget and realized the CI, which enforces compatibility with Clojure 1.7 / 1.8, was breaking.

Looks like it was due to usages of `int?` and `pos-int?`, which were added in Clojure 1.9.
I just learned a nice way to add backwards compatibility via `resolve` (via @dchelimsky in https://github.com/nubank/matcher-combinators/pull/169/files#diff-edd10e770370e8bfdbcf965fe158b67bd13cb0a6345d7a77c9c2d2f23ff06a8aR21) and I figured I'd replicate it here to allow more or less painless backwards compatibility with older versions of Clojure. This would allow https://github.com/marick/Midje/pull/480 to easily be pushed out, without concern for breaking users software. 
Sound alright?  